### PR TITLE
Rename planets to fix issue with ContractConfigurator

### DIFF
--- a/gamedata/OtherWorldsReboot/_OWPPatches/Kopernicus/OtherWorldsProgramKopernicusPatches.cfg
+++ b/gamedata/OtherWorldsReboot/_OWPPatches/Kopernicus/OtherWorldsProgramKopernicusPatches.cfg
@@ -208,8 +208,8 @@ OWP_Settings
 {
 	Body
 	{
-		name = OWR1
-		identifier = OWR/OWR1
+		name = Owr1
+		identifier = OWR/Owr1
 		
 		contractWeight = 0
 		
@@ -397,8 +397,8 @@ OWP_Settings
 {
 	Body
 	{
-		name = OWR2
-		identifier = OWR/OWR2
+		name = Owr2
+		identifier = OWR/Owr2
 		cacheFile = OtherWorldsReboot/Cache/OWR2.bin
 		
 		contractWeight = 0
@@ -413,7 +413,7 @@ OWP_Settings
 
 		Orbit
 		{
-			referenceBody = OWR/OWR1
+			referenceBody = OWR/Owr1
 			inclination = 0.28147
 			eccentricity = 0.0468
 			semiMajorAxis = 597033000

--- a/src/OtherWorldsProgram/OWP_PlanetManager.cs
+++ b/src/OtherWorldsProgram/OWP_PlanetManager.cs
@@ -25,7 +25,7 @@ namespace NiakoKerbalMods
 				get { return (PLANETS != null && PLANETS.Count > 2) ? PLANETS[1] : null; }
 			}
 
-			private static string[] PLANETS_NAMES = {"OWR1", "OWR2"};
+			private static string[] PLANETS_NAMES = {"Owr1", "Owr2"};
 
 			private static bool FirstStart = true;
 


### PR DESCRIPTION
Renames OWR1 and OWR2 to Owr1 and Owr2 which fixes an issue with ContractConfigurator incorrectly parsing the biomes due to the celestial bodies having multiple uppercase letters.