### PR TITLE
Increase minimum antenna requirement to 5km and communicate what rating is

### DIFF
--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Contracts/StellarExplorationCercani.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Contracts/StellarExplorationCercani.cfg
@@ -128,7 +128,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -196,7 +196,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -334,7 +334,7 @@ CONTRACT_TYPE
 		type = HasAntenna
 
 		antennaType = TRANSMIT
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -402,7 +402,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -517,7 +517,7 @@ CONTRACT_TYPE
 		type = HasAntenna
 
 		antennaType = TRANSMIT
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -585,7 +585,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -712,7 +712,7 @@ CONTRACT_TYPE
 		type = HasAntenna
 
 		antennaType = TRANSMIT
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -780,7 +780,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -898,7 +898,7 @@ CONTRACT_TYPE
 		type = HasAntenna
 
 		antennaType = TRANSMIT
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -966,7 +966,7 @@ CONTRACT_TYPE
 		name = HasAntenna
 		type = HasAntenna
 	
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER
@@ -1047,7 +1047,7 @@ CONTRACT_TYPE
 		type = HasAntenna
 
 		antennaType = TRANSMIT
-		minAntennaPower = 100.0
+		minAntennaPower = 4999.0
 	}
 
 	PARAMETER

--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ENG.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ENG.cfg
@@ -27,7 +27,7 @@ Localization
 		
 		#LOC_OWR_Contract_OrangeCandle_Title = Orange Candle
 		#LOC_OWR_Contract_OrangeCandle_Description = The stars have always been watching us, but we have been blinded to their secrets. Now, with the technology we have, we can learn about them.
-		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. It needs to have an antenna that can transmit at least 5 Kilometers.
+		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. This contract and all subsequent contracts in this group require the craft to have an antenna that can transmit at least 5 Kilometers.
 		#LOC_OWR_Contract_OrangeCandle_Completion = With this telescope, we are one step closer to the stars. If we ever go, we will be prepared.
 
 

--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ENG.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ENG.cfg
@@ -27,7 +27,7 @@ Localization
 		
 		#LOC_OWR_Contract_OrangeCandle_Title = Orange Candle
 		#LOC_OWR_Contract_OrangeCandle_Description = The stars have always been watching us, but we have been blinded to their secrets. Now, with the technology we have, we can learn about them.
-		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit.
+		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. It needs to have an antenna that can transmit at least 5 Kilometers.
 		#LOC_OWR_Contract_OrangeCandle_Completion = With this telescope, we are one step closer to the stars. If we ever go, we will be prepared.
 
 

--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ES.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_ES.cfg
@@ -27,7 +27,7 @@ Localization
 		
 		#LOC_OWR_Contract_OrangeCandle_Title = Orange Candle
 		#LOC_OWR_Contract_OrangeCandle_Description = The stars have always been watching us, but we have been blinded to their secrets. Now, with the technology we have, we can learn about them.
-		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit.
+		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. This contract and all subsequent contracts in this group require the craft to have an antenna that can transmit at least 5 Kilometers.
 		#LOC_OWR_Contract_OrangeCandle_Completion = With this telescope, we are one step closer to the stars. If we ever go, we will be prepared.
 
 

--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_FR.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_FR.cfg
@@ -27,7 +27,7 @@ Localization
 		
 		#LOC_OWR_Contract_OrangeCandle_Title = Orange Candle
 		#LOC_OWR_Contract_OrangeCandle_Description = The stars have always been watching us, but we have been blinded to their secrets. Now, with the technology we have, we can learn about them.
-		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit.
+		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. This contract and all subsequent contracts in this group require the craft to have an antenna that can transmit at least 5 Kilometers.
 		#LOC_OWR_Contract_OrangeCandle_Completion = With this telescope, we are one step closer to the stars. If we ever go, we will be prepared.
 
 

--- a/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_RU.cfg
+++ b/gamedata/OtherWorldsReboot/ConfigurationFiles/Localization/Localization_Contracts_RU.cfg
@@ -27,7 +27,7 @@ Localization
 		
 		#LOC_OWR_Contract_OrangeCandle_Title = Orange Candle
 		#LOC_OWR_Contract_OrangeCandle_Description = The stars have always been watching us, but we have been blinded to their secrets. Now, with the technology we have, we can learn about them.
-		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit.
+		#LOC_OWR_Contract_OrangeCandle_GenericDescription = Launch an Infrared Telescope to Solar Orbit. This contract and all subsequent contracts in this group require the craft to have an antenna that can transmit at least 5 Kilometers.
 		#LOC_OWR_Contract_OrangeCandle_Completion = With this telescope, we are one step closer to the stars. If we ever go, we will be prepared.
 
 


### PR DESCRIPTION
5km is the the base range of the worst on-board antennas, so it makes sense that this should be the minimum for all contracts in this group. (set to 4999 for safety) "Antenna rating" is also not explained very well in default KSP, so a change to the wording of the first contract is needed to make this clear.

Cool mod btw! I'm just getting started with it.